### PR TITLE
Add tooltip override

### DIFF
--- a/resources/views/livewire-line-chart.blade.php
+++ b/resources/views/livewire-line-chart.blade.php
@@ -97,6 +97,14 @@
                                 }
                             )
                         },
+                        
+                        tooltip: {
+                            y: {
+                                formatter: function(value, series) {
+                                    return component.get('lineChartModel.data')[series.dataPointIndex].extras.formatted || value;
+                                }
+                            }
+                        }
                     };
 
                     this.chart = new ApexCharts(this.$refs.container, options);


### PR DESCRIPTION
Returns value if no formatted option in extras.

For example:

```php

return $orders->groupBy('created_at')
            ->reduce(function (LineChartModel $lineChartModel, $day) {
                return $lineChartModel->addPoint($day[0]->created_at, $day->sum('amount')/100, ['formatted' => dollar_format($day->sum('amount'))]);
            }, new LineChartModel());