### PR TITLE
Changed 'emit' functions in Area,Line, and Radar chart to 'dispatch' …

### DIFF
--- a/src/Charts/LivewireAreaChart.php
+++ b/src/Charts/LivewireAreaChart.php
@@ -26,7 +26,7 @@ class LivewireAreaChart extends Component
             return;
         }
 
-        $this->emit($onPointClickEventName, $point);
+        $this->dispatch($onPointClickEventName, $point);
     }
 
     public function render()

--- a/src/Charts/LivewireLineChart.php
+++ b/src/Charts/LivewireLineChart.php
@@ -26,7 +26,7 @@ class LivewireLineChart extends Component
             return;
         }
 
-        $this->emit($onPointClickEventName, $point);
+        $this->dispatch($onPointClickEventName, $point);
     }
 
     public function render()

--- a/src/Charts/LivewireRadarChart.php
+++ b/src/Charts/LivewireRadarChart.php
@@ -26,7 +26,7 @@ class LivewireRadarChart extends Component
             return;
         }
 
-        $this->emit($onPointClickEventName, $point);
+        $this->dispatch($onPointClickEventName, $point);
     }
 
     public function render()


### PR DESCRIPTION
## Summary

Changed 'emit' functions in Area, Line, and Radar chart's onClick functions to use 'dispatch' instead.

## Issue

In the current version, clicking a point on these graph types throws an exception as the 'emit' function no longer exists in Livewire 3.

## Type of Change

- [ ] :rocket: New Feature
- [x] :bug: Bug Fix
- [ ] :hammer: Refactor
- [ ] :question: [Other]