### PR TITLE
Update helpers.js

### DIFF
--- a/resources/js/helpers.js
+++ b/resources/js/helpers.js
@@ -12,8 +12,6 @@ export const addPathToObjectWithValue = (obj, path, value) => {
 }
 
 export const mergedOptionsWithJsonConfig = (options, jsonConfig) => {
-    console.log('jsonConfig', jsonConfig);
-    console.log('options', options);
     const customOptions = Object.keys(jsonConfig)
         .reduce(function (obj, key) {
             const value = jsonConfig[key]

--- a/resources/js/helpers.js
+++ b/resources/js/helpers.js
@@ -12,15 +12,15 @@ export const addPathToObjectWithValue = (obj, path, value) => {
 }
 
 export const mergedOptionsWithJsonConfig = (options, jsonConfig) => {
+    console.log('jsonConfig', jsonConfig);
+    console.log('options', options);
     const customOptions = Object.keys(jsonConfig)
         .reduce(function (obj, key) {
             const value = jsonConfig[key]
 
-            if (typeof value === 'string' && value.includes('function')) {
-                return addPathToObjectWithValue(obj, key, eval('(' + value + ')'))
-            }
-
-            return addPathToObjectWithValue(obj, key, eval(value))
+            // Assume `value` is now directly a function or other proper JS type
+            // No need for eval(), just directly use the value
+            return addPathToObjectWithValue(obj, key, value)
         }, {})
 
     return deepmerge(options, customOptions)


### PR DESCRIPTION
## Summary

I updated helpers.js to fix a recurring problem, eval() returned a JS error:

```
Uncaught SyntaxError: Unexpected end of input
    at app-08a4b5f5.js:738:14381
    at Array.reduce (<anonymous>)
    at mergedOptionsWithJsonConfig (app-08a4b5f5.js:738:14178)
    at Proxy.drawChart (app-08a4b5f5.js:738:21078)
    at app-08a4b5f5.js:738:19964
```

_eval() with vite has "security" risk?
`resources/js/vendor/livewire-charts/helpers.js (20:58) Use of eval in "resources/js/vendor/livewire-charts/helpers.js" is strongly discouraged as it poses security risks and may cause issues with minification.`_


## Issue

No issue

## Type of Change

- [ ] :rocket: New Feature
- [x] :bug: Bug Fix
- [ ] :hammer: Refactor
- [ ] :question: [Other]

## Screenshot/Video

![image](https://github.com/asantibanez/livewire-charts/assets/138211005/805cf747-4cf9-4831-be57-14cd90d08895)

